### PR TITLE
Remove SonarCloud from CI

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -38,7 +38,10 @@
 
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, reopened]
 
 jobs:
   build:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -55,51 +55,18 @@ jobs:
     steps:
     - name: Checkout the repo
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'zulu'
-        java-version: '11'
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
-
-    - name: Cache SonarCloud packages
-      uses: actions/cache@v2.1.7
-      with:
-        path: ~\sonar\cache
-        key: ${{ runner.os }}-sonar
-        restore-keys: ${{ runner.os }}-sonar
-
-    - name: Cache SonarCloud scanner
-      id: cache-sonar-scanner
-      uses: actions/cache@v2.1.7
-      with:
-        path: .\.sonar\scanner
-        key: ${{ runner.os }}-sonar-scanner
-        restore-keys: ${{ runner.os }}-sonar-scanner
-
-    - name: Install SonarCloud scanner
-      if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
-      shell: powershell
-      run: |
-        New-Item -Path .\.sonar\scanner -ItemType Directory
-        dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
 
     # Restore the application to populate the obj folder with RuntimeIdentifiers
     - name: Build NiftyPerforce in ${{ matrix.configuration }} and analyze
       shell: powershell
       run: |
-        .\.sonar\scanner\dotnet-sonarscanner begin /k:"belkiss_niftyplugins" /o:"belkiss-github" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
         msbuild -t:build -restore NiftyPerforce/NiftyPerforce.csproj /nologo /v:m /p:DeployExtension=false /p:Configuration=$env:Configuration
-        .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
       env:
         Configuration: ${{ matrix.configuration }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
Remove SonarCloud, as it always fail with PR and gives the wrong idea about the build state of the branch