### PR TITLE
Added an 'arm64' InstallationTarget into the vsixmanifest

### DIFF
--- a/NiftyPerforce/Manifests/source.extension.vsixmanifest
+++ b/NiftyPerforce/Manifests/source.extension.vsixmanifest
@@ -22,6 +22,9 @@ SPDX-License-Identifier: MIT
       <InstallationTarget Version="[17.0,)" Id="Microsoft.VisualStudio.Community">
         <ProductArchitecture>amd64</ProductArchitecture>
       </InstallationTarget>
+      <InstallationTarget Version="[17.0,)" Id="Microsoft.VisualStudio.Community">
+        <ProductArchitecture>arm64</ProductArchitecture>
+      </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />


### PR DESCRIPTION
Simple change to support installing into Windows on Arm. My use case was Visual Studio in Parallels on macOS.
